### PR TITLE
feat: Allow deploying stack-set to organizational units

### DIFF
--- a/internal/cmd/stackset/stackset_deploy.go
+++ b/internal/cmd/stackset/stackset_deploy.go
@@ -229,8 +229,9 @@ func createStackSetName(args []string) string {
 // Validate if we have enough configuration data to create/update stack set instances
 func isInstanceConfigDataValid(c *cfn.StackSetInstancesConfig) bool {
 	if c != nil &&
-		c.Accounts != nil && len(c.Accounts) > 0 &&
-		c.Regions != nil && len(c.Regions) > 0 {
+		c.Regions != nil && len(c.Regions) > 0 &&
+		((c.Accounts != nil && len(c.Accounts) > 0) ||
+		(c.DeploymentTargets != nil && c.DeploymentTargets.OrganizationalUnitIds != nil && len(c.DeploymentTargets.OrganizationalUnitIds) > 0)) {
 		config.Debugf("ConfigData is valid\n")
 		return true
 	} else {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This merge-request add support for AWS organization: one can specify an organization root ID or organizational unit IDs instead of a list of account IDs

The configuration looks like this:

```yaml
---
StackSet:
  autodeployment:
    enabled: true
    retainstacksonaccountremoval: false

  managedexecution:
    active: true

  permissionmodel: SERVICE_MANAGED

StackSetInstanses:
  operationpreferences:
    regionconcurrencytype: PARALLEL
    maxconcurrentpercentage: 100
    failuretolerancepercentage: 80

  regions:
    - ap-northeast-1
    - ap-northeast-2
    - ap-northeast-3
    - ap-south-1
    - ap-southeast-1
    - ap-southeast-2
    - ca-central-1
    - eu-central-1
    - eu-north-1
    - eu-west-1
    - eu-west-2
    - eu-west-3
    - sa-east-1
    - us-east-1
    - us-east-2
    - us-west-1
    - us-west-2

  deploymenttargets:
    organizationalunitids:
      - r-tj456
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
